### PR TITLE
Use api key_id for deletation instead of description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+sftp.json

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Features included:
 * Added support to hide the connect button if Fortnox API key and Your ID key field is empty.
 * Added support to call for a function on button click with AJAX.
 * Added support for translation. At present, the plugin is available in English and Swedish.
+
+**1.1.2 - 2019-09-14**
+
+**Added**
+* Creation of API keys also stores the key_id field in the options table 
+* Deletetion of the API keys is now based on the key_id field
+* Prepare function to send json data to a Fortnox endpoint
+* Added .gitignore file

--- a/classes/woocommerce-integration.php
+++ b/classes/woocommerce-integration.php
@@ -6,8 +6,6 @@
 
 class WoocommerceIntegration {
 
-    private $key;
-
     public function user_has_api_key($user_id) {
         global $wpdb;
         $result = $wpdb->get_results("SELECT consumer_key FROM wp_woocommerce_api_keys WHERE description = 'Woocommerce-Fortnox-Integration'");

--- a/classes/woocommerce-integration.php
+++ b/classes/woocommerce-integration.php
@@ -1,12 +1,12 @@
 <?php
-
 /**
  * Provides functions for the plugin settings page in the WordPress admin.
  * @license   GPL-3.0
  */
 
-class WoocommerceIntegration
-{
+class WoocommerceIntegration {
+
+    private $key;
 
     public function user_has_api_key($user_id) {
         global $wpdb;
@@ -40,7 +40,7 @@ class WoocommerceIntegration
             $wpdb->prefix . 'woocommerce_api_keys',
             array(
                 'user_id' => $user->ID,
-                'description' => "Woocommerce-Fortnox-Integration",
+                'description' => $app_name,
                 'permissions' => $permissions,
                 'consumer_key' => wc_api_hash($consumer_key),
                 'consumer_secret' => $consumer_secret,
@@ -56,17 +56,21 @@ class WoocommerceIntegration
             )
         );
 
+        add_option( 'woo_key_id', $wpdb->insert_id, '', 'yes' );
+
         return array(
             'key_id' => $wpdb->insert_id,
-            'user_id' => $app_user_id,
+            'user_id' => $user_id,
             'consumer_key' => $consumer_key,
             'consumer_secret' => $consumer_secret,
             'key_permissions' => $permissions,
         );
     }
 
-    public function destroy_api_keys($app_name) {
+    public function destroy_api_keys() {
         global $wpdb;
-        $wpdb->query("DELETE FROM wp_woocommerce_api_keys WHERE description = '$app_name'");
+        $key_id = get_option('woo_key_id');
+        $wpdb->delete('wp_woocommerce_api_keys', array('key_id' => $key_id));
+        delete_option('woo_key_id');
     }
 }

--- a/woocommerce-fortnox-integration.php
+++ b/woocommerce-fortnox-integration.php
@@ -28,31 +28,53 @@ if (!defined('ABSPATH')) {
 require_once __DIR__ . '/classes/woocommerce-integration.php';
 require_once __DIR__ . '/includes/admin/class-fortnox-settings.php';
 
+function set_app_name() {
+    return $app_name = "Woocommerce-Fortnox-Integration";
+}
+
 function create_api_keys() {
     if (!wp_verify_nonce($_POST['nonce'], 'ajax-fortnox-integration')) {
         wp_die();
     }
 
     $app_user_id = get_user_id();
-    $app_name = "Woocommerce-Fortnox-Integration";
+    $app_name = set_app_name();
     $scope = "Standout";
     $woocommerce_integration = new WoocommerceIntegration();
     $woocommerce_integration->generate_api_keys($app_user_id, $app_name, $scope);
 }
+add_action('wp_ajax_connect_to_fortnox', 'create_api_keys', 5);
 
-add_action('wp_ajax_connect_to_fortnox', 'create_api_keys');
+function json_to_fortnox() {
+    global $wpdb;
+    $current_user_id = get_user_id();
+    $stored_woo_api_keys = $wpdb->get_results("SELECT consumer_key,consumer_secret FROM wp_woocommerce_api_keys WHERE user_id =".$current_user_id);
+    $fortnox_auth_key = get_option('fortnox_authorization_key');
+    $fortnox_key_id = get_option('fortnox_id_key');
+    $consumer_key = $stored_woo_api_keys[0]->consumer_key;
+    $consumer_secret = $stored_woo_api_keys[0]->consumer_secret;
+    $domain = $_SERVER['SERVER_NAME'];
+
+    $response = array(
+        'fortnox_auth_key' => $fortnox_auth_key,
+        'fortnox_key_id'=> $fortnox_key_id,
+        'woo_consumer_key'=> $consumer_key,
+        'woo_consumer_secret' => $consumer_secret,
+        'domain' => $domain
+    );
+
+    wp_send_json($response);
+}
+add_action('wp_ajax_connect_to_fortnox', 'json_to_fortnox', 10);
 
 function destroy_api_keys() {
     if (!wp_verify_nonce($_POST['nonce'], 'ajax-fortnox-integration')) {
         wp_die();
     }
 
-    $app_user_id = get_user_id();
-    $app_name = "Woocommerce-Fortnox-Integration";
     $woocommerce_integration = new WoocommerceIntegration();
-    $woocommerce_integration->destroy_api_keys($app_name);
+    $woocommerce_integration->destroy_api_keys();
 }
-
 add_action('wp_ajax_disconnect_from_fortnox', 'destroy_api_keys');
 
 function get_user_id() {
@@ -73,11 +95,9 @@ function admin_ajax() {
         'nonce' => wp_create_nonce('ajax-fortnox-integration'),
     ));
 }
-
 add_action('admin_enqueue_scripts', 'admin_ajax');
 
 function fortnox_integration_load_textdomain() {
   load_plugin_textdomain( 'fortnox-integration', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 }
-
 add_action( 'plugins_loaded', 'fortnox_integration_load_textdomain' );

--- a/woocommerce-fortnox-integration.php
+++ b/woocommerce-fortnox-integration.php
@@ -47,8 +47,8 @@ add_action('wp_ajax_connect_to_fortnox', 'create_api_keys', 5);
 
 function json_to_fortnox() {
     global $wpdb;
-    $current_user_id = get_user_id();
-    $stored_woo_api_keys = $wpdb->get_results("SELECT consumer_key,consumer_secret FROM wp_woocommerce_api_keys WHERE user_id =".$current_user_id);
+    $key_id = get_option('woo_key_id');
+    $stored_woo_api_keys = $wpdb->get_results("SELECT consumer_key,consumer_secret FROM wp_woocommerce_api_keys WHERE key_id =".$key_id);
     $fortnox_auth_key = get_option('fortnox_authorization_key');
     $fortnox_key_id = get_option('fortnox_id_key');
     $consumer_key = $stored_woo_api_keys[0]->consumer_key;

--- a/woocommerce-fortnox-integration.php
+++ b/woocommerce-fortnox-integration.php
@@ -89,7 +89,7 @@ function get_user_id() {
 add_action('plugins_loaded', 'get_user_id', 5);
 
 function admin_ajax() {
-    wp_enqueue_script('ajax-script', plugins_url('/includes/admin/js/admin.js', __FILE__), array('jquery'), '1.1.1');
+    wp_enqueue_script('ajax-script', plugins_url('/includes/admin/js/admin.js', __FILE__), array('jquery'), '1.1.2');
 
     wp_localize_script('ajax-script', 'fortnox', array(
         'nonce' => wp_create_nonce('ajax-fortnox-integration'),


### PR DESCRIPTION
https://standoutab.atlassian.net/jira/software/projects/PROD/boards/1?selectedIssue=PROD-376
https://extrabrain.se/projects/1385/tasks/25317

Deletation of api keys is now based on the key_id instead of the description.
Prepared function for sending json data to a Fortnox endpoint.